### PR TITLE
Fixed name regex in short_methods/robot_name.rb 

### DIFF
--- a/short_methods/robot_name.rb
+++ b/short_methods/robot_name.rb
@@ -19,7 +19,7 @@ class Robot
       @name = "#{generate_char.call}#{generate_char.call}#{generate_num.call}#{generate_num.call}#{generate_num.call}"
     end
 
-    raise NameCollisionError, 'There was a problem generating the robot name!' if !(name =~ /\w{2|\d{3}/) || @@registry.include?(name)
+    raise NameCollisionError, 'There was a problem generating the robot name!' if !(name =~ /[[:alpha:]]{2}[[:digit:]]{3}/) || @@registry.include?(name)
     @@registry << @name
   end
 


### PR DESCRIPTION
Previous regex was malformed, and also matched the first two
characters to any alphanumeric character rather than any
alphabetical character

Fix uses POSIX bracket expressions which will also match 
non-ASCII characters
