### PR TITLE
updated to not enforce the 'prefer fail over raise'

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -17,3 +17,7 @@ Style/EachWithObject:
 # C: Removing the preference for string single quotes
 Style/StringLiterals:
   Enabled: false
+
+#C: Prefer fail over raise
+Style/SignalException:
+  Enabled: false


### PR DESCRIPTION
this is the rubocop fix to allow "raise" statements (it defaults to prefer "fail" otherwise)
