### PR TITLE
Robot name 20141001 rc

### DIFF
--- a/robot_name/robot_name.rb
+++ b/robot_name/robot_name.rb
@@ -55,5 +55,3 @@ puts "My pet robot's name is #{robot.name}, but we usually call him sparky."
 generator = -> { 'AA111' }
 Robot.new(name_generator: generator)
 Robot.new(name_generator: generator)
-
-puts "My pet robot's name is #{robot.name}, but we usually call him sparky."


### PR DESCRIPTION
Refactor of the Robot Name exercise. Split the `initialize` method into numerous smaller methods. Split error message into two separate messages allowing for more detail.

I'm not a huge fan of the `generate_new_name` method, my thinking was that anything more clever/dynamic would need to tie into `valid_name` so that the robot naming format could be changed from one place instead of two.
