### PR TITLE
add dinosaur that breaks everyone's period.split(' ').last == value code

### DIFF
--- a/dino_catalog/dinodex.csv
+++ b/dino_catalog/dinodex.csv
@@ -8,3 +8,4 @@ Megalosaurus,Jurassic,Europe,Carnivore,2200,Biped,Originally thought to be a Qua
 Giganotosaurus,Late Cretaceous,South America,Carnivore,30420,Biped,Largest hunter and also the coolest ever.
 Quetzalcoatlus,Late Cretaceous,North America,Carnivore,440,Quadruped,Largest known flying animal of all time.
 Yangchuanosaurus,Oxfordian,Asia,Carnivore,7200,Biped,
+Dracopelta,Early Cretaceous or Late Jurassic,South America,Herbivore,,Quadruped,One of the most primitive known Ankylosauria.


### PR DESCRIPTION
I like to be mean. More importantly, the "all observed period values are two words, the latter of which is the actual period" is a really brittle approach. Add a dinosaur that makes clear that this approach doesn't work well on real datasets.