### PR TITLE
Fixing dependency assumptions with Overlord exercise

### DIFF
--- a/overlord/lib/wire_bundle.rb
+++ b/overlord/lib/wire_bundle.rb
@@ -1,3 +1,5 @@
+require_relative "wire"
+
 class WireBundle
   attr_reader :wires
 


### PR DESCRIPTION
The WireBundle class is explicitly coupled with the Wire class, so the dependency should be explicitly declared.