### PR TITLE
Deja/dino_catalog (version 2)

### DIFF
--- a/dino_catalog/criterium.rb
+++ b/dino_catalog/criterium.rb
@@ -1,0 +1,83 @@
+class Criterium
+  def initialize(criterium)
+    @tokens = criterium.split
+    set_defaults
+    process_tokens
+  end
+
+  def to_hash
+    filter_args = {}
+    filter_args[@field.to_sym] = @value
+    filter_args.merge!(op: @op, negate: @negate)
+    filter_args
+  end
+
+  private
+
+  def process_tokens
+    @field = @tokens.shift
+    if boolean?
+      process_boolean
+    else
+      process_op
+      process_value
+    end
+  end
+
+  def boolean?
+    %w(is are).include?(@field)
+  end
+
+  def negation?(token)
+    @negate = token != "!="
+    @negate &&= (%w(not !).include?(token) || token[0] == "!")
+    @negate
+  end
+
+  def process_boolean
+    @field = @tokens.shift
+    @op = "=="
+    @value = true
+    @field = process_negation(@field)
+  end
+
+  def process_negation(token)
+    return token unless negation?(token)
+    if token[0] == "!"
+      token[0] = ""
+    else
+      token = @tokens.shift
+    end
+    token
+  end
+
+  def process_op
+    @op = @tokens.shift
+    process_negation(@op)
+  end
+
+  def process_value
+    val = @tokens.join(" ")
+    @value = typecast(val)
+  end
+
+  def set_defaults
+    @negate = false
+    @field = ""
+    @op = "=="
+    @value = ""
+  end
+
+  def make_numeric_if_applicable(item)
+    Float(item)
+  rescue TypeError, ArgumentError
+    item
+  end
+
+  def typecast(item)
+    item = make_numeric_if_applicable(item)
+    item = true if item.is_a?(String) && item.downcase == "true"
+    item = false if item.is_a?(String) && item.downcase == "false"
+    item
+  end
+end

--- a/dino_catalog/dino_catalog.rb
+++ b/dino_catalog/dino_catalog.rb
@@ -1,54 +1,150 @@
 require 'json'
 require_relative 'dinodex'
+require_relative 'criterium'
+require_relative 'errors'
+require_relative 'import_loop'
 
-puts
-puts "***********"
-puts "* Dinodex *"
-puts "***********"
-puts
+class DinodexApp
+  ALLOWED_COMMANDS = %w(help ? exit done quit)
 
-dex = Dinodex.new
+  TEXT_INTRO = <<-eos
+***********
+* Dinodex *
+***********
 
-dex.import("dinodex.csv")
-dex.import("african_dinosaur_export.csv")
+Welcome to the Dinodex!
+The following data files are available, which would you like to use?
 
-puts "---------------"
-puts "  Query: All carnivores larger than 2,000 lbs"
-puts
-dex.filter(weight: 2000, op: ">")
-  .filter(carnivore: true)
-  .each do |dino|
-  puts dino.to_s
-  puts
+eos
+
+  TEXT_HELP = <<-eos
+
+***** HELP *****
+
+Format: [is |are [not ]]<field> [not |! ]<operator> <value>[ and ...][as json]
+
+
+Queries typically comprise three components:
+ <field> - the name of a field.
+           e.g. name, period, diet
+ <operator> - how to compare the field to the value.
+              e.g. >, <, ==, include?, start_with?
+ <value> - the value to compare the field against.
+           e.g. 2000, true, Cretaceous, North America
+
+A negated comparison can be made by placing "not" or "!" before the operator
+e.g. continent !include? America, name not start_with? Albert
+
+Multiple criteria can be combined using "and"
+e.g. weight <= 2000 and period != Early Cretaceous
+
+One exception to the standard query format is with boolean fields.
+You can test a boolean field is true by preceeding the field with
+"is", "is not", "are", or "are not"'
+e.g. is not carnivore? and period include? Cretaceous and name include? saur
+
+Optionally, the results can be printed in JSON format by appending "as json"
+to the end of a query.
+
+eos
+
+  TEXT_GOODBYE = <<-eos
+
+Thank you for using the Dinodex!
+
+eos
+
+  TEXT_DATABASE_READY = <<-eos
+
+The database is now ready to be queried.
+
+eos
+
+  TEXT_RESULTS = <<-eos
+
+----------------
+    Begin Query: %s
+
+%s
+
+    End Query: %s
+----------------
+
+eos
+
+  TEXT_QUERY_PROMPT = <<-eos
+
+Enter your query or a command: (use "help" or "?" for more info)
+
+eos
+
+  def command_help
+    puts TEXT_HELP
+    true
+  end
+
+  alias_method :command_?, :command_help
+
+  def command_exit
+    puts TEXT_GOODBYE
+    false
+  end
+
+  alias_method :command_done, :command_exit
+  alias_method :command_quit, :command_exit
+
+  def parse_criteria(criteria)
+    criteria.each do |criterium|
+      segment = Criterium.new(criterium)
+      yield(segment.to_hash)
+    end
+  end
+
+  def check_commands(query)
+    return unless ALLOWED_COMMANDS.include?(query)
+    continue = send("command_#{query}")
+    raise CommandException.new(continue: continue), "Command Found"
+  end
+
+  def parse_format(query)
+    @format = query.match(/as json$/i) ? "json" : "s"
+    query.gsub(/as json$/i, '')
+  end
+
+  def parse_query(query)
+    parsed = parse_format(query)
+    parsed.split(" and ")
+  end
+
+  def query_prompt
+    puts TEXT_QUERY_PROMPT
+    gets.chomp
+  end
+
+  def query
+    query = query_prompt
+    check_commands(query)
+    criteria = parse_query(query)
+    parse_criteria(criteria) { |filter_args| @dex.filter(filter_args) }
+    puts format(TEXT_RESULTS, query, @dex.method("to_#{@format}").call, query)
+  end
+
+  def query_loop
+    loop do
+      begin
+        query
+      rescue CommandException => e
+        break unless e.continue
+      end
+    end
+  end
+
+  def run
+    @dex = Dinodex.new
+    ImportLoop.new(@dex).run_loop
+    query_loop
+  end
 end
 
-puts "---------------"
-puts "  Query: All Cretaceous bipeds"
-puts
-dex.filter(walking: "Biped")
-  .filter(period: "Cretaceous", op: "include?")
-  .each do |dino|
-  puts dino.to_s
-  puts
-end
-
-puts "---------------"
-puts "  Query: All non-American dinosaurs ('they terk er jerbs!')"
-puts
-dex.filter(continent: "America", op: "include?", negate: true)
-  .each do |dino|
-  puts dino.to_s
-  puts
-end
-
-puts "--------------"
-puts "  Query: All \"Albert's\" as JSON"
-puts
-puts dex.filter(name: "Albert", op: "start_with?").to_json
-puts
-
-puts "--------------"
-puts "  Query: All \"Albert's\" as JSON (pretty)"
-puts
-puts JSON.pretty_generate(dex.filter(name: "Albert", op: "start_with?").to_hash)
-puts
+app = DinodexApp.new
+app.run

--- a/dino_catalog/dino_catalog.rb
+++ b/dino_catalog/dino_catalog.rb
@@ -1,0 +1,54 @@
+require 'json'
+require_relative 'dinodex'
+
+puts
+puts "***********"
+puts "* Dinodex *"
+puts "***********"
+puts
+
+dex = Dinodex.new
+
+dex.import("dinodex.csv")
+dex.import("african_dinosaur_export.csv")
+
+puts "---------------"
+puts "  Query: All carnivores larger than 2,000 lbs"
+puts
+dex.filter(weight: 2000, op: ">")
+  .filter(carnivore: true)
+  .each do |dino|
+  puts dino.to_s
+  puts
+end
+
+puts "---------------"
+puts "  Query: All Cretaceous bipeds"
+puts
+dex.filter(walking: "Biped")
+  .filter(period: "Cretaceous", op: "include?")
+  .each do |dino|
+  puts dino.to_s
+  puts
+end
+
+puts "---------------"
+puts "  Query: All non-American dinosaurs ('they terk er jerbs!')"
+puts
+dex.filter(continent: "America", op: "include?", negate: true)
+  .each do |dino|
+  puts dino.to_s
+  puts
+end
+
+puts "--------------"
+puts "  Query: All \"Albert's\" as JSON"
+puts
+puts dex.filter(name: "Albert", op: "start_with?").to_json
+puts
+
+puts "--------------"
+puts "  Query: All \"Albert's\" as JSON (pretty)"
+puts
+puts JSON.pretty_generate(dex.filter(name: "Albert", op: "start_with?").to_hash)
+puts

--- a/dino_catalog/dinodex.rb
+++ b/dino_catalog/dinodex.rb
@@ -1,0 +1,60 @@
+require 'csv'
+require_relative 'dinosaur'
+
+class Dinodex
+  attr_reader :db
+
+  def initialize
+    @db = []
+  end
+
+  def import(filename)
+    db.concat(parse_csv(filename))
+  end
+
+  def parse_csv(filename)
+    csv = CSV.new(IO.read(filename), headers: true, converters: :all)
+
+    csv.to_a.map { |row| Dinosaur.new(row.to_hash) }
+  end
+
+  def filters
+    @filter ||= []
+  end
+
+  def filter(args)
+    args[:op] ||= "=="
+    filters.push(args)
+    self
+  end
+
+  def each(&block)
+    db.reject do |dino|
+      !match_dino(dino)
+    end.each(&block)
+  end
+
+  def match_dino(dino)
+    match = 1
+
+    filters.each do |filter|
+      op = filter[:op]
+      key,target = filter.first
+      value = dino.method(key).call
+
+      match = match & 0 unless value && value.method(op).(target)
+    end
+
+    match == 1
+  end
+end
+
+dex = Dinodex.new
+
+dex.import("dinodex.csv")
+dex.import("african_dinosaur_export.csv")
+
+dex.filter({ weight: 2000, op: ">" }).filter({ carnivore: true }).each do |dino|
+  puts dino.to_s
+  puts
+end

--- a/dino_catalog/dinosaur.rb
+++ b/dino_catalog/dinosaur.rb
@@ -5,12 +5,6 @@ class Dinosaur
   alias_method :genus=, :name=
   alias_method :weight_in_lbs=, :weight=
 
-  def initialize(args = {})
-    args.each do |key, value|
-      send("#{key.downcase}=", value)
-    end
-  end
-
   def carnivore
     @diet.downcase != "herbivore"
   end
@@ -20,14 +14,33 @@ class Dinosaur
     @diet = "Herbivore" if value.downcase == "no"
   end
 
-  def to_s
-    instance_variables.map do |ivar|
+  def initialize(args = {})
+    args.each do |key, value|
+      send("#{key.downcase}=", value)
+    end
+  end
+
+  def to_hash
+    out = instance_variables.map do |ivar|
       vname = ivar.to_s
       vname[0] = ""
 
       value = instance_variable_get(ivar)
-
-      "#{vname.capitalize}: #{value}" if value
+      [vname, value]
     end
+
+    Hash[out]
+  end
+
+  def to_s
+    out = instance_variables.map do |ivar|
+      vname = ivar.to_s
+      vname[0] = ""
+
+      value = instance_variable_get(ivar)
+      "#{format('%12s', vname.capitalize)}:\t#{value}" if value
+    end
+
+    out.compact.join("\n")
   end
 end

--- a/dino_catalog/dinosaur.rb
+++ b/dino_catalog/dinosaur.rb
@@ -5,7 +5,7 @@ class Dinosaur
   alias_method :genus=, :name=
   alias_method :weight_in_lbs=, :weight=
 
-  def carnivore
+  def carnivore?
     @diet.downcase != "herbivore"
   end
 
@@ -21,26 +21,25 @@ class Dinosaur
   end
 
   def to_hash
-    out = instance_variables.map do |ivar|
-      vname = ivar.to_s
-      vname[0] = ""
-
-      value = instance_variable_get(ivar)
-      [vname, value]
-    end
-
+    out = ivars { |vname, value| [vname, value] }
     Hash[out]
   end
 
   def to_s
-    out = instance_variables.map do |ivar|
-      vname = ivar.to_s
-      vname[0] = ""
-
-      value = instance_variable_get(ivar)
+    out = ivars do |vname, value|
       "#{format('%12s', vname.capitalize)}:\t#{value}" if value
     end
-
     out.compact.join("\n")
+  end
+
+  private
+
+  def ivars
+    instance_variables.map do |ivar|
+      vname = ivar.to_s
+      vname[0] = ""
+      value = instance_variable_get(ivar)
+      yield(vname, value)
+    end
   end
 end

--- a/dino_catalog/dinosaur.rb
+++ b/dino_catalog/dinosaur.rb
@@ -1,0 +1,33 @@
+class Dinosaur
+  attr_accessor :name, :period, :continent, :diet
+  attr_accessor :weight, :walking, :description
+
+  alias_method :genus=, :name=
+  alias_method :weight_in_lbs=, :weight=
+
+  def initialize(args = {})
+    args.each do |key, value|
+      send("#{key.downcase}=", value)
+    end
+  end
+
+  def carnivore
+    @diet.downcase != "herbivore"
+  end
+
+  def carnivore=(value)
+    @diet = "Carnivore" if value.downcase == "yes"
+    @diet = "Herbivore" if value.downcase == "no"
+  end
+
+  def to_s
+    instance_variables.map do |ivar|
+      vname = ivar.to_s
+      vname[0] = ""
+
+      value = instance_variable_get(ivar)
+
+      "#{vname.capitalize}: #{value}" if value
+    end
+  end
+end

--- a/dino_catalog/errors.rb
+++ b/dino_catalog/errors.rb
@@ -1,0 +1,7 @@
+class CommandException < StandardError
+  attr_accessor :continue
+
+  def initialize(args)
+    @continue = args[:continue]
+  end
+end

--- a/dino_catalog/import_loop.rb
+++ b/dino_catalog/import_loop.rb
@@ -1,0 +1,88 @@
+class ImportLoop
+  TEXT_IMPORT_PROMPT = <<-eos
+[all] Use all available data files
+
+Enter a file number (default: all):
+eos
+
+  TEXT_IMPORT_MORE_PROMPT = <<-eos
+
+  Would you like to load another file? (Y/n)
+
+eos
+
+  TEXT_INVALID_SELECTION = <<-eos
+
+Invalid selection. Please try again:
+
+eos
+
+  def initialize(dinodex)
+    @dex = dinodex
+    @sources = Dir["*.csv"]
+  end
+
+  def import_prompt
+    @sources.each_with_index { |f, i| puts "[#{i}] #{f}" }
+    puts TEXT_IMPORT_PROMPT
+    gets.chomp
+  end
+
+  def import_more_prompt?
+    return false unless @sources.count > 0
+    puts TEXT_IMPORT_MORE_PROMPT
+    return false if %w(no n).include?(gets.chomp.downcase)
+    true
+  end
+
+  def integer_or_false(i)
+    Integer(i)
+  rescue
+    false
+  end
+
+  def parse_index(index)
+    i = integer_or_false(index)
+    return i if i && i.between?(0, @sources.count)
+    false
+  end
+
+  def import_all
+    @sources.each { |f| @dex.import(f) }
+    puts
+    puts "Loaded all available data files!"
+    false
+  end
+
+  def import_single(offset)
+    file = @sources[offset]
+    @dex.import(file)
+    @sources.delete(file)
+    puts "#{file} loaded!"
+    import_more_prompt?
+  end
+
+  def invalid_option
+    puts TEXT_INVALID_SELECTION
+    true
+  end
+
+  def loop_step(index, offset)
+    if offset != false
+      import_single(offset)
+    elsif index.downcase == "all" || index.empty?
+      import_all
+    else
+      invalid_option
+    end
+  end
+
+  def run_loop
+    loop do
+      index = import_prompt
+      offset = parse_index(index)
+
+      break unless loop_step(index, offset)
+    end
+  end
+end


### PR DESCRIPTION
- Refactored core logic to drastically simplify matching / filtering logic
- Built interactive CLI interface
- Core class interface remains backward-compatible, so the original examples (such as the one below) will still work without modification:

```
dex = Dinodex.new
dex.import("dinodex.csv")
dex.import("african_dinosaur_export.csv")
dex.filter(continent: "America", op: "include?", negate: true)
   .filter(carnivore: true)
dex.each do |dino|
  puts dino
  puts
end
```