### PR TITLE
Overlord: Fixed bomb activation issue

### DIFF
--- a/overlord/lib/bomb.rb
+++ b/overlord/lib/bomb.rb
@@ -29,10 +29,7 @@ class Bomb
   end
 
   def enter_code(code)
-    unless code.nil?
-      try_activation(code) if inactive?
-      try_deactivation(code) if active?
-    end
+    try_code(code) unless code.nil?
 
     self
   end
@@ -100,5 +97,10 @@ class Bomb
     @error = :bad_code
     @failed_deactivations += 1
     explode if failed_deactivations >= max_failed_deactivations
+  end
+
+  def try_code(code)
+    return try_activation(code) if inactive?
+    try_deactivation(code) if active?
   end
 end

--- a/overlord/spec/bomb_spec.rb
+++ b/overlord/spec/bomb_spec.rb
@@ -4,6 +4,7 @@ describe Bomb do
   let(:activation_code) { "1234" }
   let(:deactivation_code) { "0000" }
   let(:bad_code) { "bad_code" }
+
   subject(:bomb) { described_class.new(activation_code, deactivation_code) }
 
   describe "#new" do
@@ -43,6 +44,12 @@ describe Bomb do
         let(:code) { activation_code }
 
         it { is_expected.to be_active }
+
+        context "when activation/deactivation codes are identical" do
+          let(:deactivation_code) { activation_code }
+
+          it { is_expected.to be_active }
+        end
       end
 
       context "when entering the deactivation code" do


### PR DESCRIPTION
Bomb would not activate when activation and deactivation codes were
identical.