### PR TITLE
remove lines in .hound.yml referencing 'Style/TrailingComma'

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -25,9 +25,6 @@ Style/StringLiterals:
 Style/SignalException:
   Enabled: false
 
-Style/TrailingComma:
-  EnforcedStyleForMultiline: comma
-
 # This never works for validations
 Style/AlignHash:
   EnforcedLastArgumentHashStyle: ignore_implicit


### PR DESCRIPTION
As of [rubocop 0.36.0](https://github.com/bbatsov/rubocop/releases/tag/v0.36.0), the 'Style/TrailingComma' cop has been split out. This was causing [an error](https://github.com/Homebrew/homebrew/issues/48105) when running rubocop against the triangle_facts exercise.