### PR TITLE
Refactor RobotName to short methods

### DIFF
--- a/robot_name/robot.rb
+++ b/robot_name/robot.rb
@@ -1,0 +1,51 @@
+require_relative 'robot_name'
+
+class NameCollisionError < RuntimeError; end
+
+class Robot
+  CHARS = ('A'..'Z').to_a
+  NUMS = (1..10).to_a
+  ERROR_MESSAGE = 'There was a problem generating the robot name!'.freeze
+
+  attr_accessor :name
+
+  def initialize(args = {})
+    @name_generator = args[:name_generator]
+    @name = create_name
+    add_name_to_registry
+  end
+
+  def create_name
+    return @name_generator.call if @name_generator
+    generate_name
+  end
+
+  def generate_name
+    CHARS.sample(2).join + NUMS.shuffle.take(3).join
+  end
+
+  def valid_name?
+    valid_format? && not_in_the_registry?
+  end
+
+  def valid_format?
+    @name =~ /[[:alpha:]]{2}[[:digit:]]{3}/
+  end
+
+  def not_in_the_registry?
+    !RobotNames.registry.include?(@name)
+  end
+
+  def add_name_to_registry
+    raise NameCollisionError, ERROR_MESSAGE unless valid_name?
+    RobotNames.add_to_registry(@name)
+  end
+end
+
+# robot = Robot.new
+# puts "My pet robot's name is #{robot.name}, but we usually call him sparky."
+
+# Errors!
+generator = -> { 'AA111' }
+Robot.new(name_generator: generator)
+Robot.new(name_generator: generator)

--- a/robot_name/robot_name.rb
+++ b/robot_name/robot_name.rb
@@ -1,24 +1,42 @@
 class NameCollisionError < RuntimeError; end
 
 class Robot
-  attr_accessor :name
+  CHARS = ('A'..'Z').to_a
+  NUMS = (1..10).to_a
 
   @@registry
+  attr_accessor :name
 
   def initialize(args = {})
     @@registry ||= []
     @name_generator = args[:name_generator]
+    @name = get_name
+    add_name_to_registry
+  end
 
-    if @name_generator
-      @name = @name_generator.call
-    else
-      generate_char = -> { ('A'..'Z').to_a.sample }
-      generate_num = -> { rand(10) }
+  def get_name
+    return @name_generator.call if @name_generator
+    generate_name
+  end
 
-      @name = "#{generate_char.call}#{generate_char.call}#{generate_num.call}#{generate_num.call}#{generate_num.call}"
-    end
+  def generate_name
+    name = CHARS.sample(2).join + NUMS.shuffle.take(3).join
+  end
 
-    raise NameCollisionError, 'There was a problem generating the robot name!' if !(name =~ /[[:alpha:]]{2}[[:digit:]]{3}/) || @@registry.include?(name)
+  def valid_name?
+    valid_format? && not_in_the_registry?
+  end
+
+  def valid_format?
+    @name =~ /[[:alpha:]]{2}[[:digit:]]{3}/
+  end
+
+  def not_in_the_registry?
+    !@@registry.include?(@name)
+  end
+
+  def add_name_to_registry
+    raise NameCollisionError, 'There was a problem generating the robot name!' unless valid_name?
     @@registry << @name
   end
 end

--- a/robot_name/robot_name.rb
+++ b/robot_name/robot_name.rb
@@ -1,50 +1,11 @@
-class NameCollisionError < RuntimeError; end
+class RobotNames
+  @registry ||= []
 
-class Robot
-  CHARS = ('A'..'Z').to_a
-  NUMS = (1..10).to_a
-
-  @@registry
-  attr_accessor :name
-
-  def initialize(args = {})
-    @@registry ||= []
-    @name_generator = args[:name_generator]
-    @name = get_name
-    add_name_to_registry
+  class << self
+    attr_accessor :registry
   end
 
-  def get_name
-    return @name_generator.call if @name_generator
-    generate_name
-  end
-
-  def generate_name
-    name = CHARS.sample(2).join + NUMS.shuffle.take(3).join
-  end
-
-  def valid_name?
-    valid_format? && not_in_the_registry?
-  end
-
-  def valid_format?
-    @name =~ /[[:alpha:]]{2}[[:digit:]]{3}/
-  end
-
-  def not_in_the_registry?
-    !@@registry.include?(@name)
-  end
-
-  def add_name_to_registry
-    raise NameCollisionError, 'There was a problem generating the robot name!' unless valid_name?
-    @@registry << @name
+  def self.add_to_registry(name)
+    @registry << name
   end
 end
-
-robot = Robot.new
-puts "My pet robot's name is #{robot.name}, but we usually call him sparky."
-
-# Errors!
-# generator = -> { 'AA111' }
-# Robot.new(name_generator: generator)
-# Robot.new(name_generator: generator)


### PR DESCRIPTION
I retain the `NameCollisionError` class and `@@registry`. I want the
`initialize` method to only accept a var instead of hash but ruby
doesn't allow an optional parameter. I THINK this is better than my
previous attempt, all functions are still the same. I'm not sure
about my `not_in_the_registry?` method since I use negation there.

Thank you for your awesome feedback!